### PR TITLE
Created placeholder connection context

### DIFF
--- a/src/context/ConnectionContext.js
+++ b/src/context/ConnectionContext.js
@@ -1,0 +1,19 @@
+import React from "react";
+
+const ConnectionContext = React.createContext();
+
+function ConnectionProvider({ children }) {
+  // The establishConnection function returns a promise that resolves to
+  // a connection object. Provide this promise directly (instead of
+  // waiting for it to resolve) so that the app can render right away.
+  const connection = "This placeholder represents the connection object"; // establishConnection();
+
+  return (
+    <ConnectionContext.Provider value={connection}>
+      {children}
+    </ConnectionContext.Provider>
+  );
+}
+
+export { ConnectionProvider };
+export default ConnectionContext; // Provides a promise. Use like this: const connection = await useContext(ConnectionContext);

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,22 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
-import { HashRouter } from 'react-router-dom';
-import { AuthProvider } from './context/AuthContext';
+import React from "react";
+import ReactDOM from "react-dom";
+import App from "./App";
+import reportWebVitals from "./reportWebVitals";
+import { HashRouter } from "react-router-dom";
+import { AuthProvider } from "./context/AuthContext";
+import { ConnectionProvider } from "./context/ConnectionContext";
+
 ReactDOM.render(
   <React.StrictMode>
-    <AuthProvider>
-      <HashRouter>
-        <App />
-      </HashRouter>
-    </AuthProvider>
+    <ConnectionProvider>
+      <AuthProvider>
+        <HashRouter>
+          <App />
+        </HashRouter>
+      </AuthProvider>
+    </ConnectionProvider>
   </React.StrictMode>,
-  document.getElementById('root')
+  document.getElementById("root")
 );
 
 // If you want to start measuring performance in your app, pass a function


### PR DESCRIPTION
Hi team,

This PR creates a place to put the `establishConnection` function from this afternoon's dev call. As discussed then, the connection should be created as soon as the app launches and needs to be available throughout the app. The following changes were made to prepare for that:

### `src/context/ConnectionContext.js`
This file creates a wrapper component called `ConnectionProvider`, and in the body of that component is where the connection can be created.

### `src/index.js`
Here the entire app is wrapped in the `ConnectionProvider` component, which ensures it is called on launch and makes the associated context (i.e. the connection) available from anywhere in the app's component tree.