### PR TITLE
[run `npm install`] Enabled TypeScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,14 +14,18 @@
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.3",
         "@testing-library/user-event": "^13.5.0",
+        "@types/react": "^18.0.6",
+        "@types/react-dom": "^18.0.2",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-router-dom": "^6.2.2",
         "react-scripts": "5.0.0",
         "sass": "^1.49.9",
+        "typescript": "^4.6.3",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@tsconfig/create-react-app": "^1.0.2",
         "electron": "^17.1.2",
         "foreman": "^3.0.1"
       }
@@ -3498,6 +3502,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@tsconfig/create-react-app": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/create-react-app/-/create-react-app-1.0.2.tgz",
+      "integrity": "sha512-Vg+pErSM6hTcSzxPqNwFg0dk+y0R1Obp8uLV1MDdfd7j98FyOFqtqkdxb9wqIx9vtDW5GCH7zg6DyoHJzMT12g==",
+      "dev": true
+    },
     "node_modules/@types/aria-query": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
@@ -3720,9 +3730,9 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "node_modules/@types/react": {
-      "version": "17.0.39",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
-      "integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
+      "version": "18.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.6.tgz",
+      "integrity": "sha512-bPqwzJRzKtfI0mVYr5R+1o9BOE8UEXefwc1LwcBtfnaAn6OoqMhLa/91VA8aeWfDPJt1kHvYKI8RHcQybZLHHA==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -3730,9 +3740,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.13",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.13.tgz",
-      "integrity": "sha512-wEP+B8hzvy6ORDv1QBhcQia4j6ea4SFIBttHYpXKPFZRviBvknq0FRh3VrIxeXUmsPkwuXVZrVGG7KUVONmXCQ==",
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.2.tgz",
+      "integrity": "sha512-UxeS+Wtj5bvLRREz9tIgsK4ntCuLDo0EcAcACgw3E+9wE8ePDr9uQpq53MfcyxyIS55xJ+0B6mDS8c4qkkHLBg==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -15710,10 +15720,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
-      "peer": true,
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19212,6 +19221,12 @@
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
       "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA=="
     },
+    "@tsconfig/create-react-app": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/create-react-app/-/create-react-app-1.0.2.tgz",
+      "integrity": "sha512-Vg+pErSM6hTcSzxPqNwFg0dk+y0R1Obp8uLV1MDdfd7j98FyOFqtqkdxb9wqIx9vtDW5GCH7zg6DyoHJzMT12g==",
+      "dev": true
+    },
     "@types/aria-query": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
@@ -19434,9 +19449,9 @@
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "@types/react": {
-      "version": "17.0.39",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.39.tgz",
-      "integrity": "sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==",
+      "version": "18.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.6.tgz",
+      "integrity": "sha512-bPqwzJRzKtfI0mVYr5R+1o9BOE8UEXefwc1LwcBtfnaAn6OoqMhLa/91VA8aeWfDPJt1kHvYKI8RHcQybZLHHA==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -19444,9 +19459,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "17.0.13",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.13.tgz",
-      "integrity": "sha512-wEP+B8hzvy6ORDv1QBhcQia4j6ea4SFIBttHYpXKPFZRviBvknq0FRh3VrIxeXUmsPkwuXVZrVGG7KUVONmXCQ==",
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.2.tgz",
+      "integrity": "sha512-UxeS+Wtj5bvLRREz9tIgsK4ntCuLDo0EcAcACgw3E+9wE8ePDr9uQpq53MfcyxyIS55xJ+0B6mDS8c4qkkHLBg==",
       "requires": {
         "@types/react": "*"
       }
@@ -28122,10 +28137,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
-      "peer": true
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw=="
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,14 @@
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^13.5.0",
+    "@types/react": "^18.0.6",
+    "@types/react-dom": "^18.0.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.2.2",
     "react-scripts": "5.0.0",
     "sass": "^1.49.9",
+    "typescript": "^4.6.3",
     "web-vitals": "^2.1.4"
   },
   "scripts": {
@@ -46,6 +49,7 @@
     ]
   },
   "devDependencies": {
+    "@tsconfig/create-react-app": "^1.0.2",
     "electron": "^17.1.2",
     "foreman": "^3.0.1"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@tsconfig/create-react-app/tsconfig.json"
+}


### PR DESCRIPTION
Hi team,

After doing some reading starting with the helpful link posted in this afternoon's meeting, I decided to test my knowledge by attempting to get TypeScript working in this repo. It worked in the end, so I thought it would be good to share the benefits here.

Here are some steps to take after pulling these changes:
- Run `npm install`
- Enjoy the freedom to write in either JavaScript or TypeScript, as you please
- To start the app, run `npm start` as usual.

Here is a wonderful guide to TypeScript:
- https://www.typescriptlang.org/docs

Here are the steps I took:
- Read the docs, had issues at first, read things on stackoverflow.com, still had issues, etc. The usual process of migrating to something new.
- Ran `npm install typescript @types/react @types/react-dom` as described in [1] (link below). Didn't bother installing `@types/node` or `@types/jest`, even though the article [1] said to, because we are not using Node or Jest.
- Ran `npm install --save-dev @tsconfig/create-react-app` and wrote the contents of `tsconfig.json` after reading https://github.com/tsconfig/bases/ (found that link while reading [4])
- Tried it out. Changed a random file name extension from `.js` to `.tsx`, fixed whatever TypeScript complained about, and ran `npm start` without any problems. Undid the changes in that file, set its extension back to `.js`, and ran `npm start` again without any problems.

Here is some of what I read:
- [1] (minimal migration instruction) https://blog.bitsrc.io/why-and-how-use-typescript-in-your-react-app-60e8987be8de
- [2] (someone praising TypeScript) https://slack.engineering/typescript-at-slack/
- [3] (the basics of TypeScript) https://www.typescriptlang.org/docs/handbook/2/basic-types.html
- [4] (where to get a pre-defined tsconfig) https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#tsconfig-bases
